### PR TITLE
Add an optional parameter "ScholarAdjustment"

### DIFF
--- a/axie-scholar-utilities/source/axie/payments.py
+++ b/axie-scholar-utilities/source/axie/payments.py
@@ -354,7 +354,7 @@ class AxiePaymentsManager:
             total_payments = 0
             acc_payments = []
             # Scholar Payment
-            scholar_amount = acc_balance * (acc["ScholarPercent"]/100)
+            scholar_amount = (acc_balance * (acc["ScholarPercent"]/100)) + acc.get("ScholarAdjustment", 0)
             scholar_amount += acc.get("ScholarPayout", 0)
             scholar_amount = round(scholar_amount)
             acc_payments.append(Payment(

--- a/axie-scholar-utilities/source/axie/schemas.py
+++ b/axie-scholar-utilities/source/axie/schemas.py
@@ -40,6 +40,9 @@ payments_schema = {
                         "type": "number",
                         "minimum": 1
                     },
+                    "ScholarAdjustment": {
+                        "type": "number",
+                    },
                     "TrainerPayoutAddress": {
                         "type": "string",
                         "pattern": "^ronin:"
@@ -127,6 +130,9 @@ payments_percent_schema = {
                     "ScholarPayout": {
                         "type": "number",
                         "minimum": 1
+                    },
+                    "ScholarAdjustment": {
+                        "type": "number",
                     },
                     "ScholarPercent": {
                         "type": "number",

--- a/axie-scholar-utilities/source/tests/normal/test_schema_validation.py
+++ b/axie-scholar-utilities/source/tests/normal/test_schema_validation.py
@@ -433,6 +433,7 @@ def test_json_validator_payments_percent_schema_error(json_input, expected_error
                     "AccountAddress": "ronin:<account_s1_address>",
                     "ScholarPayoutAddress": "ronin:<scholar_address>",
                     "ScholarPercent": 50,
+                    "ScholarAdjustment": -100
                     "TrainerPayoutAddress": "ronin:<trainer_address>",
                     "TrainerPercent": 10
                 },
@@ -441,6 +442,7 @@ def test_json_validator_payments_percent_schema_error(json_input, expected_error
                     "AccountAddress": "ronin:<account_s2_address>",
                     "ScholarPayoutAddress": "ronin:<scholar2_address>",
                     "ScholarPercent": 55,
+                    "ScholarAdjustment": +100
                     "TrainerPayoutAddress": "ronin:<trainer_address>",
                     "TrainerPercent": 14,
                     "TrainerPayout": 100


### PR DESCRIPTION
Add an optional parameter "ScholarAdjustment" that is used for scholar deduction and bonus.

For Example:

Deducts a -100 SLP to scholar
![image](https://user-images.githubusercontent.com/12708526/153078924-68ed440a-c523-4942-9d54-f0650707cb44.png)

Adds a +100 SLP to scholar
![image](https://user-images.githubusercontent.com/12708526/153078937-0bdfffbb-fd91-44fb-8d62-3e7833b030f9.png)
